### PR TITLE
Creating an admin account in terminal works with the bash script.

### DIFF
--- a/admin-setup.sh
+++ b/admin-setup.sh
@@ -1,0 +1,9 @@
+read -p "Enter admin name: " adminName
+read -p "Enter admin email: " adminEmail
+read -p "Enter admin password: " adminPassword
+
+user='{ "name": "'"$adminName"'", "email": "'"$adminEmail"'", "password": "'"$adminPassword"'" }'
+curl --header "Content-Type: application/json" \
+     --request POST \
+     --data "$user" \
+     http://localhost:8080/api/users/register


### PR DESCRIPTION
This works as of now, only locally while in development. Further work is needed for production with environment variables, DockerHub, GitHub pipeline etc (don't know how this works unfortunately).

How to try it:

Remove account in localstorage, just like it would when setting up everything from scratch.

Go to the terminal, to the root directory of the app.
Enter the following:
`chmod +x admin-setup.sh`
`./admin-setup.sh`
Then you can enter you credentials for registering as an admin.