### PR TITLE
Fix for adding a tag with empty string and adding duplicate tags.

### DIFF
--- a/client/src/pages/Add.js
+++ b/client/src/pages/Add.js
@@ -119,9 +119,17 @@ function Add(props) {
     }
 
     const appendTag = () => {
-        tags.push(tag)
-        setTag('')
-        document.getElementById('tag-input').value = ''
+        // Makes sure it is not an empty tag
+        if (tag)
+        {   
+            if (!tags.includes(tag)){
+                // Covers the event of trying to add a duplicate tag
+                tags.push(tag);
+            } 
+            setTag('');
+            document.getElementById('tag-input').value = '';
+        }
+        
     }
 
     const check_tag_exists = (t) => {


### PR DESCRIPTION
Implemented a way to check for not trying to add an empty string as  a tag + adding a duplicate tag.